### PR TITLE
tickescdisp and tickclosdisp json changes

### DIFF
--- a/dispatchers/tickcloseddisp.json
+++ b/dispatchers/tickcloseddisp.json
@@ -77,7 +77,7 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "id": { "type": "string" },
+                              "id": { "type": "integer" },
                               "value": { "type": "string" }
                             },
                             "required": [ "id", "value" ]
@@ -98,7 +98,7 @@
                                 }
                               },
                               "body": { "type": "string" },
-                              "id": { "type": "string" }
+                              "id": { "type": "integer" }
                             },
                             "required": [ "id", "body", "attachments" ],
                             "type": "object"
@@ -107,10 +107,10 @@
                         },
                         "created_at": { "type": "string" },
                         "description": { "type": "string" },
-                        "id": { "type": "string" },
+                        "id": { "type": "integer" },
                         "organization": {
                           "properties": {
-                            "id": { "type": "string" },
+                            "id": { "type": "integer" },
                             "name": { "type": "string" },
                             "organization_fields": {
                               "properties": {
@@ -159,7 +159,7 @@
                         "requester": {
                           "properties": {
                             "email": { "type": "string" },
-                            "id": { "type": "string" },
+                            "id": { "type": "integer" },
                             "name": { "type": "string" },
                             "phone": { "type": "string" },
                             "user_fields": {

--- a/dispatchers/tickescdisp.json
+++ b/dispatchers/tickescdisp.json
@@ -77,7 +77,7 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "id": { "type": "string" },
+                              "id": { "type": "integer" },
                               "value": { "type": "string" }
                             },
                             "required": [ "id", "value" ]
@@ -98,7 +98,7 @@
                                 }
                               },
                               "body": { "type": "string" },
-                              "id": { "type": "string" }
+                              "id": { "type": "integer" }
                             },
                             "required": [ "id", "body", "attachments" ],
                             "type": "object"
@@ -107,10 +107,10 @@
                         },
                         "created_at": { "type": "string" },
                         "description": { "type": "string" },
-                        "id": { "type": "string" },
+                        "id": { "type": "integer" },
                         "organization": {
                           "properties": {
-                            "id": { "type": "string" },
+                            "id": { "type": "integer" },
                             "name": { "type": "string" },
                             "organization_fields": {
                               "properties": {
@@ -159,7 +159,7 @@
                         "requester": {
                           "properties": {
                             "email": { "type": "string" },
-                            "id": { "type": "string" },
+                            "id": { "type": "integer" },
                             "name": { "type": "string" },
                             "phone": { "type": "string" },
                             "user_fields": {


### PR DESCRIPTION
Updated tickcloseddiso and tickescdisp json files to make id related attributes type as integer from string to bring it inline with the Zendesk webhook changes